### PR TITLE
docs: document calendar integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Chatty is an intelligent agent that combines complex reasoning with several help
 - **Web search and page browsing** &ndash; Query DuckDuckGo and summarize the contents of specific web pages for up-to-date information.
 - **Weather reports** &ndash; Automatically detect your location and fetch forecasts from weather.gov.
 - **Restricted Python execution** &ndash; Run code safely in a persistent sandbox for calculations or quick experiments.
+- **Google Calendar integration** &ndash; List, create, and delete events after authenticating with your Google account.
 - **Smart home automation** &ndash; Control Kasa smart lights by turning them on/off, adjusting brightness, or reading their current state.
 - **Web-based interface** &ndash; Launch a FastAPI-powered UI to chat with the assistant from your browser.
 
@@ -18,6 +19,7 @@ Chatty is an intelligent agent that combines complex reasoning with several help
 - Check the weather for your current location or for specific coordinates.
 - Explore or prototype tool-augmented agent behaviours.
 - Manage smart home devices such as Kasa lights.
+- Review and manage events from your Google Calendar.
 - Use a browser-based interface for a more visual chat experience.
 
 ## Getting Started
@@ -37,7 +39,12 @@ Chatty is an intelligent agent that combines complex reasoning with several help
    ```bash
    ollama pull gpt-oss:20b
    ```
-4. Choose an interface to start:
+4. (Optional) Set up Google Calendar access by placing your `credentials.json` file in the project directory and running:
+   ```bash
+   python generateToken.py
+   ```
+   This completes the OAuth flow and creates `token.json` for the calendar tools.
+5. Choose an interface to start:
    - **Command line**
      ```bash
      python gpt-oss-tools.py
@@ -46,7 +53,7 @@ Chatty is an intelligent agent that combines complex reasoning with several help
      ```bash
      python gpt-oss-tools.py --web --host 127.0.0.1 --port 7860
      ```
-5. Type your questions or commands. In the CLI, enter `bye` to exit the session or /reset to clear context.
+6. Type your questions or commands. In the CLI, enter `bye` to exit the session or /reset to clear context.
 
 ## License
 


### PR DESCRIPTION
## Summary
- document Google Calendar tools and OAuth token generation
- include optional calendar setup in getting started steps

## Testing
- `python -m py_compile calendarTools.py generateToken.py`


------
https://chatgpt.com/codex/tasks/task_e_68969181700083339b923ac04ea62b6c